### PR TITLE
agents: prefer gh CLI over MCP for private repo access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ For each change, cross-check against the following references when the condition
 
 | When to Apply | What to Apply | How to Access |
 |---|---|---|
-| Structural or foundational changes | Ensure that changes conform with the [Architecture principles](https://github.com/camunda/product-development/tree/main/architecture/principles) | Use the `github` MCP server to access the principles |
+| Structural or foundational changes | Ensure that changes conform with the [Architecture principles](https://github.com/camunda/product-development/tree/main/architecture/principles) | If `gh` is installed and authenticated as a Camunda user, use `gh api` to fetch content from the private repo. Otherwise, use the `github` MCP server, which has authentication already configured. |
 | Any change needing Camunda domain knowledge | Gather required knowledge from the Camunda 8 Docs | Use the `camunda-docs` MCP server |
 
 ## Build Standards


### PR DESCRIPTION
## Summary
- When `gh` is installed and authenticated as a Camunda user, agents now use `gh api` directly to fetch content from the private architecture principles repo
- Falls back to the `github` MCP server (which has auth pre-configured) when `gh` is not available (e.g. web UI usage)
- Reduces token overhead by avoiding MCP schema and JSON envelope costs

## Test plan
- [ ] Verify agents with `gh` installed use `gh api` for architecture principles
- [ ] Verify agents without `gh` fall back to MCP server

🤖 Generated with [Claude Code](https://claude.com/claude-code)