### PR TITLE
feat: add agent skills for architecture and docs checks

### DIFF
--- a/.github/workflows/test-setup-scripts.yml
+++ b/.github/workflows/test-setup-scripts.yml
@@ -1,0 +1,26 @@
+name: Test setup scripts
+
+on:
+  pull_request:
+    paths:
+      - 'mcp/**'
+      - 'skills/**'
+      - 'tests/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Ensure gh 2.90.0+
+        run: |
+          gh --version
+          gh extension install gh-skill 2>/dev/null || true
+          if ! gh skill --help >/dev/null 2>&1; then
+            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+            sudo apt-get update && sudo apt-get install -y gh
+          fi
+          gh --version
+      - name: Run smoke tests
+        run: ./tests/setup-scripts.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,10 +18,17 @@ Before implementing every change:
 
 For each change, cross-check against the following references when the condition applies:
 
-| When to Apply | What to Apply | How to Access |
-|---|---|---|
-| Structural or foundational changes | Ensure that changes conform with the [Architecture principles](https://github.com/camunda/product-development/tree/main/architecture/principles) | Use the `github` MCP server to access the principles |
-| Any change needing Camunda domain knowledge | Gather required knowledge from the Camunda 8 Docs | Use the `camunda-docs` MCP server |
+| When to Apply | What to Apply |
+|---|---|
+| Structural or foundational changes | Ensure that changes conform with the [Architecture principles](https://github.com/camunda/product-development/tree/main/architecture/principles). Use the `check-architecture-principles` skill. |
+| Any change needing Camunda domain knowledge | Gather required knowledge from the Camunda 8 Docs. Use the `check-camunda-docs` skill. |
+
+## Tooling Preconditions
+
+At the start of every session, verify the following:
+
+1. **GitHub CLI (`gh`)** — run `gh auth status`. If it fails or is not installed, notify the engineer and point them to https://cli.github.com. `gh` must be installed and authenticated to access Camunda's private repositories.
+2. **Skill freshness** — run `gh skill update` to check for outdated skills. If any skill has a pending update, suggest running `gh skill update --all` before proceeding.
 
 ## Build Standards
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ For each change, cross-check against the following references when the condition
 
 At the start of every session, verify the following:
 
-1. **GitHub CLI (`gh`)** — run `gh auth status`. If it fails or is not installed, notify the engineer and point them to https://cli.github.com. `gh` must be installed and authenticated to access Camunda's private repositories. If `gh` is not available or not authenticated, fall back to the `github` MCP server for repository access.
+1. **GitHub CLI (`gh`)** — run `gh auth status`. If it fails or is not installed, notify the engineer and point them to https://cli.github.com. `gh` must be installed and authenticated to access Camunda's private repositories. If `gh` is not available or not authenticated (e.g., 404/invalid token in web-agent sessions), fall back to the `github` MCP server for repository access.
 2. **Skill freshness** — run `gh skill update` to check for outdated skills. If any skill has a pending update, suggest running `gh skill update --all` before proceeding.
 
 ## Build Standards

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ For each change, cross-check against the following references when the condition
 
 At the start of every session, verify the following:
 
-1. **GitHub CLI (`gh`)** — run `gh auth status`. If it fails or is not installed, notify the engineer and point them to https://cli.github.com. `gh` must be installed and authenticated to access Camunda's private repositories.
+1. **GitHub CLI (`gh`)** — run `gh auth status`. If it fails or is not installed, notify the engineer and point them to https://cli.github.com. `gh` must be installed and authenticated to access Camunda's private repositories. If `gh` is not available or not authenticated, fall back to the `github` MCP server for repository access.
 2. **Skill freshness** — run `gh skill update` to check for outdated skills. If any skill has a pending update, suggest running `gh skill update --all` before proceeding.
 
 ## Build Standards

--- a/README.md
+++ b/README.md
@@ -12,13 +12,22 @@
 
 [`AGENTS.md`](AGENTS.md) provides development instructions for AI coding agents working in Camunda repositories. It defines how agents should classify changes (linear, structural, foundational), plan before implementing, and cross-check against key references such as architecture principles and Camunda 8 documentation.
 
-### MCP Server Configurations (`mcp/`)
+### Developer Setup
 
-The [`mcp/`](mcp/) directory contains company-wide [MCP (Model Context Protocol)](https://modelcontextprotocol.io/) server configurations and a setup script for VS Code, Claude Desktop, and JetBrains IDEs. It provides access to:
+Set up your local environment for AI-assisted development in two steps:
 
-- **`camunda-docs`** — Camunda 8 documentation search
-- **`github`** — GitHub tools via Copilot MCP proxy (VS Code only)
+1. **MCP servers** — give agents access to Camunda docs and GitHub tools
+   ```bash
+   cd mcp && ./setup.sh
+   ```
+   See [`mcp/README.md`](mcp/README.md) for details.
 
-Run `mcp/setup.sh` to install the configurations into your local IDE. See [`mcp/README.md`](mcp/README.md) for details.
+2. **Agent skills** — give agents Camunda-specific capabilities
+   ```bash
+   cd skills && ./setup.sh
+   ```
+   See [`skills/README.md`](skills/README.md) for details.
+
+### Onboarding a Repository
 
 Follow the instructions in https://github.com/camunda/ai-first-template for how to onboard your repo for using this AI-First framework.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,45 @@
+# Camunda Agent Skills
+
+This directory contains organization-wide [Agent Skills](https://agentskills.io) that extend AI coding agents with Camunda-specific capabilities.
+
+## Quick start
+
+```bash
+git clone https://github.com/camunda/.github.git
+cd .github/skills
+./setup.sh              # interactive — choose which agents to configure
+```
+
+Or pass flags directly:
+
+```bash
+./setup.sh --agent claude-code    # Claude Code only
+./setup.sh --all                  # all supported agents
+```
+
+## Available skills
+
+| Skill | Description |
+|---|---|
+| `check-architecture-principles` | Validates structural/foundational changes against Camunda architecture principles |
+| `check-camunda-docs` | Searches Camunda 8 docs for domain knowledge needed during implementation |
+
+## Prerequisites
+
+- **GitHub CLI** v2.90.0+ with the `gh skill` extension
+- **MCP servers** configured via [`mcp/setup.sh`](../mcp/README.md) — the skills depend on the `github` and `camunda-docs` MCP servers
+
+## Keeping skills up to date
+
+Skills are checked for freshness by the agent at the start of every session (see [AGENTS.md](../AGENTS.md#skill-freshness)). When updates are available, the agent will nudge you to run:
+
+```bash
+gh skill update --all
+```
+
+## Adding a new skill
+
+1. Create a new directory under `skills/` matching the skill name (lowercase, hyphens only).
+2. Add a `SKILL.md` with the required frontmatter (`name`, `description`) and instructions.
+3. Update the table above.
+4. Commit — others can then install via `gh skill install camunda/.github <skill-name>`.

--- a/skills/README.md
+++ b/skills/README.md
@@ -17,6 +17,8 @@ Or pass flags directly:
 ./setup.sh --all                  # all supported agents
 ```
 
+If you run `./setup.sh` from inside a git checkout that contains these skills, the script automatically installs from that local checkout.
+
 ## Available skills
 
 | Skill | Description |
@@ -31,7 +33,7 @@ Or pass flags directly:
 
 ## Keeping skills up to date
 
-Skills are checked for freshness by the agent at the start of every session (see [AGENTS.md](../AGENTS.md#skill-freshness)). When updates are available, the agent will nudge you to run:
+Skills are checked for freshness by the agent at the start of every session (see [AGENTS.md](../AGENTS.md#tooling-preconditions)). When updates are available, the agent will nudge you to run:
 
 ```bash
 gh skill update --all

--- a/skills/check-architecture-principles/SKILL.md
+++ b/skills/check-architecture-principles/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: check-architecture-principles
+description: Validates structural or foundational code changes against Camunda architecture principles. Use when a change alters module boundaries, APIs, data flows, core architecture, domain models, or protocols.
+compatibility: Requires gh CLI (preferred) or the `github` MCP server as fallback
+metadata:
+  author: camunda
+---
+
+# Check Architecture Principles
+
+## When to use
+
+Use this skill before implementing any **structural** or **foundational** change:
+
+- **Structural:** Refactors that change module boundaries, APIs, data flows, or responsibilities
+- **Foundational:** Changes to core architecture, domain model, protocols, or persistence
+
+Do not use for linear changes (flags, constants, simple feature tweaks).
+
+## Procedure
+
+### 1. Fetch the architecture principles
+
+Try `gh` first. Fall back to MCP if `gh` is unavailable or returns an error (e.g., 404 may indicate missing authentication).
+
+**Primary — `gh` CLI:**
+
+```bash
+# List principle documents
+gh api repos/camunda/product-development/contents/architecture/principles --jq '.[].name'
+
+# Read a specific principle
+gh api repos/camunda/product-development/contents/architecture/principles/{filename} --jq '.content' | base64 -d
+```
+
+**Fallback — `github` MCP server:**
+
+Use the `github` MCP server to read the contents of `architecture/principles` in the `camunda/product-development` repo. Use this when `gh` is not available (e.g., web UI environments).
+
+Read each principle document found.
+
+### 2. Evaluate conformance
+
+For each principle, evaluate whether the planned change conforms or conflicts. Produce a checklist:
+
+```
+Architecture Conformance:
+- [ ] Principle: [name] — [conformant / not applicable / conflict]
+```
+
+### 3. Handle conflicts
+
+If any principle conflicts with the planned change:
+- Stop and report the conflict to the engineer
+- Suggest an alternative approach that conforms
+- Do not proceed with implementation until the engineer explicitly approves the deviation
+
+### 4. Proceed
+
+If all principles are conformant or not applicable, proceed with implementation.

--- a/skills/check-architecture-principles/SKILL.md
+++ b/skills/check-architecture-principles/SKILL.md
@@ -21,7 +21,7 @@ Do not use for linear changes (flags, constants, simple feature tweaks).
 
 ### 1. Fetch the architecture principles
 
-Try `gh` first. Fall back to MCP if `gh` is unavailable or returns an error (e.g., 404 may indicate missing authentication).
+Try `gh` first. Fall back to GitHub MCP if `gh` is unavailable or returns an error (e.g., 404 may indicate missing authentication).
 
 **Primary — `gh` CLI:**
 

--- a/skills/check-camunda-docs/SKILL.md
+++ b/skills/check-camunda-docs/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: check-camunda-docs
+description: Searches Camunda 8 documentation for domain knowledge needed during implementation. Use when a change involves Camunda-specific concepts, APIs, configuration, or behavior — such as BPMN, DMN, Zeebe, Connectors, Operate, Tasklist, Identity, or any Camunda platform component.
+compatibility: Requires the `camunda-docs` MCP server configured via camunda/.github/mcp/setup.sh
+metadata:
+  author: camunda
+---
+
+# Check Camunda Docs
+
+## When to use
+
+Use this skill when implementing any change that involves Camunda domain knowledge:
+
+- Camunda platform components (Zeebe, Operate, Tasklist, Identity, Optimize, Connectors, Console)
+- BPMN or DMN modeling concepts
+- Camunda APIs, SDKs, or client libraries
+- Configuration, deployment, or operational behavior
+- Error codes, status types, or domain-specific enumerations
+
+## Procedure
+
+### 1. Identify relevant concepts
+
+Identify the Camunda concepts relevant to the current change.
+
+### 2. Search documentation
+
+Query the `camunda-docs` MCP server with a focused search term.
+
+- Prefer specific terms over broad ones (e.g., "Zeebe gateway timeout configuration" over "Zeebe config")
+- If the first query returns insufficient results, refine and retry with alternative terms
+
+### 3. Extract relevant knowledge
+
+From the returned documentation, extract:
+- Correct API signatures, configuration keys, or behavioral guarantees
+- Constraints or limitations that affect the implementation
+- Recommended patterns from the official docs
+
+### 4. Apply and flag discrepancies
+
+Apply what you learned to the implementation. If the documentation contradicts the current code, flag the discrepancy to the engineer before changing behavior.

--- a/skills/setup.sh
+++ b/skills/setup.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+#
+# Camunda Agent Skills Setup
+# Installs organization-wide agent skills into your local agent configuration.
+#
+# Usage: ./setup.sh [--agent <name>] [--all] [--dry-run] [-h|--help]
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="camunda/.github"
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+info()    { echo -e "  $*"; }
+success() { echo -e "${GREEN}✔${NC} $*"; }
+warn()    { echo -e "${YELLOW}⚠${NC} $*"; }
+error()   { echo -e "${RED}✘${NC} $*" >&2; }
+
+DRY_RUN=false
+
+# ---------------------------------------------------------------------------
+# Discover skills — each subdirectory containing a SKILL.md
+# ---------------------------------------------------------------------------
+discover_skills() {
+  local skills=()
+  for dir in "$SCRIPT_DIR"/*/; do
+    [[ -f "$dir/SKILL.md" ]] && skills+=("$(basename "$dir")")
+  done
+  echo "${skills[@]}"
+}
+
+# ---------------------------------------------------------------------------
+# Install a single skill
+# ---------------------------------------------------------------------------
+install_skill() {
+  local skill="$1" agent_flag="${2:-}"
+
+  if $DRY_RUN; then
+    info "Would run: gh skill install $REPO $skill $agent_flag"
+    return
+  fi
+
+  local output
+  if output=$(gh skill install "$REPO" "$skill" $agent_flag 2>&1); then
+    success "$skill installed${agent_flag:+ ($agent_flag)}"
+  elif [[ "$output" == *"already"* ]]; then
+    info "$skill already installed${agent_flag:+ ($agent_flag)} (skipped)"
+  else
+    error "$skill failed — $output"
+    return 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+usage() {
+  cat << 'EOF'
+Usage: setup.sh [OPTIONS]
+
+Install Camunda agent skills into your local agent configuration.
+If no options are given, the script runs interactively.
+
+Options:
+  --agent <name>   Install for a specific agent (claude-code, cursor, codex, gemini)
+                   Can be specified multiple times. Default: installs for GitHub Copilot.
+  --all            Install for all supported agents
+  --dry-run        Show what would be done without installing
+  -h, --help       Show this help message
+
+Examples:
+  ./setup.sh                          # Interactive
+  ./setup.sh --agent claude-code      # Claude Code only
+  ./setup.sh --all                    # All agents
+  ./setup.sh --dry-run                # Preview
+EOF
+}
+
+interactive() {
+  echo ""
+  echo -e "${BOLD}Camunda Agent Skills Setup${NC}"
+  echo ""
+
+  local skills
+  read -ra skills <<< "$(discover_skills)"
+  echo "  Skills to install:"
+  for s in "${skills[@]}"; do
+    echo "    - $s"
+  done
+  echo ""
+  echo "  1) GitHub Copilot (default)"
+  echo "  2) Claude Code"
+  echo "  3) Cursor"
+  echo "  4) Codex"
+  echo "  5) Gemini CLI"
+  echo "  a) All    q) Quit"
+  echo ""
+  read -rp "Choose agents (comma-separated, e.g. 1,2): " choice
+  [[ "$choice" == [qQ] ]] && exit 0
+
+  local agent_flags=()
+  if [[ "$choice" == [aA] ]]; then
+    agent_flags=("" "--agent claude-code" "--agent cursor" "--agent codex" "--agent gemini")
+  else
+    IFS=',' read -ra sel <<< "$choice"
+    for s in "${sel[@]}"; do
+      case "$(echo "$s" | tr -d ' ')" in
+        1) agent_flags+=("") ;;
+        2) agent_flags+=("--agent claude-code") ;;
+        3) agent_flags+=("--agent cursor") ;;
+        4) agent_flags+=("--agent codex") ;;
+        5) agent_flags+=("--agent gemini") ;;
+        *) warn "Unknown: $s" ;;
+      esac
+    done
+  fi
+
+  for flag in "${agent_flags[@]}"; do
+    for skill in "${skills[@]}"; do
+      install_skill "$skill" "$flag"
+    done
+  done
+
+  echo ""
+  if $DRY_RUN; then
+    warn "Dry run — nothing was installed."
+  else
+    success "Done. Skills will be checked for updates by the agent at session start."
+  fi
+}
+
+main() {
+  command -v gh &>/dev/null || { error "GitHub CLI (gh) is required — install from https://cli.github.com"; exit 1; }
+
+  # gh skill requires v2.90.0+
+  local gh_version
+  gh_version=$(gh --version | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+  local required="2.90.0"
+  if printf '%s\n%s\n' "$required" "$gh_version" | sort -V -C 2>/dev/null; then
+    : # version is sufficient
+  else
+    error "GitHub CLI v${required}+ is required for 'gh skill' (found v${gh_version})"
+    info "Upgrade with: brew upgrade gh (macOS) or see https://cli.github.com"
+    exit 1
+  fi
+
+  local agent_flags=()
+  local install_all=false
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --agent)    shift; agent_flags+=("--agent $1") ;;
+      --all)      install_all=true ;;
+      --dry-run)  DRY_RUN=true ;;
+      -h|--help)  usage; exit 0 ;;
+      *)          error "Unknown option: $1"; usage; exit 1 ;;
+    esac
+    shift
+  done
+
+  local skills
+  read -ra skills <<< "$(discover_skills)"
+
+  if [[ ${#skills[@]} -eq 0 ]]; then
+    error "No skills found in $SCRIPT_DIR"; exit 1
+  fi
+
+  # No flags — go interactive
+  if ! $install_all && [[ ${#agent_flags[@]} -eq 0 ]]; then
+    interactive; exit 0
+  fi
+
+  if $install_all; then
+    agent_flags=("" "--agent claude-code" "--agent cursor" "--agent codex" "--agent gemini")
+  fi
+
+  # Default to Copilot if no agent specified
+  [[ ${#agent_flags[@]} -eq 0 ]] && agent_flags+=("")
+
+  for flag in "${agent_flags[@]}"; do
+    for skill in "${skills[@]}"; do
+      install_skill "$skill" "$flag"
+    done
+  done
+
+  echo ""
+  if $DRY_RUN; then
+    warn "Dry run — nothing was installed."
+  else
+    success "Done. Skills will be checked for updates by the agent at session start."
+  fi
+}
+
+main "$@"

--- a/skills/setup.sh
+++ b/skills/setup.sh
@@ -146,7 +146,7 @@ interactive() {
     echo "    - $s"
   done
   echo ""
-  echo "  1) GitHub Copilot / VS Code (default)"
+  echo "  1) GitHub Copilot / VSCode (default)"
   echo "  2) Claude Code"
   echo "  3) Cursor"
   echo "  4) Codex"

--- a/skills/setup.sh
+++ b/skills/setup.sh
@@ -25,6 +25,26 @@ error()   { echo -e "${RED}✘${NC} $*" >&2; }
 
 DRY_RUN=false
 
+SUPPORTED_AGENTS="claude-code cursor codex gemini"
+
+# ---------------------------------------------------------------------------
+# Portable semver comparison (sort -V is not available on macOS by default)
+# ---------------------------------------------------------------------------
+version_ge() {
+  local a="$1" b="$2"
+  local a_major a_minor a_patch b_major b_minor b_patch
+
+  IFS='.' read -r a_major a_minor a_patch <<< "$a"
+  IFS='.' read -r b_major b_minor b_patch <<< "$b"
+
+  (( a_major > b_major )) && return 0
+  (( a_major < b_major )) && return 1
+  (( a_minor > b_minor )) && return 0
+  (( a_minor < b_minor )) && return 1
+  (( a_patch >= b_patch )) && return 0
+  return 1
+}
+
 # ---------------------------------------------------------------------------
 # Discover skills — each subdirectory containing a SKILL.md
 # ---------------------------------------------------------------------------
@@ -57,12 +77,19 @@ auto_detect_local_source() {
 
 # ---------------------------------------------------------------------------
 # Install a single skill
+# Usage: install_skill <skill_name> [agent_name]
+#   If agent_name is empty, installs for GitHub Copilot (default).
 # ---------------------------------------------------------------------------
 install_skill() {
-  local skill="$1" agent_flag="${2:-}"
+  local skill="$1"
+  local agent="${2:-}"
+  local label="${agent:-github-copilot}"
+
   local cmd=(gh skill install "$SOURCE" "$skill")
   $SOURCE_IS_LOCAL && cmd+=(--from-local)
-  [[ -n "$agent_flag" ]] && cmd+=($agent_flag)
+  if [[ -n "$agent" ]]; then
+    cmd+=(--agent "$agent")
+  fi
 
   if $DRY_RUN; then
     info "Would run: ${cmd[*]}"
@@ -71,11 +98,11 @@ install_skill() {
 
   local output
   if output=$("${cmd[@]}" 2>&1); then
-    success "$skill installed${agent_flag:+ ($agent_flag)}"
+    success "$skill installed ($label)"
   elif [[ "$output" == *"already"* ]]; then
-    info "$skill already installed${agent_flag:+ ($agent_flag)} (skipped)"
+    info "$skill already installed ($label) (skipped)"
   else
-    error "$skill failed — $output"
+    error "$skill failed ($label) — $output"
     return 1
   fi
 }
@@ -119,7 +146,7 @@ interactive() {
     echo "    - $s"
   done
   echo ""
-  echo "  1) GitHub Copilot (default)"
+  echo "  1) GitHub Copilot / VS Code (default)"
   echo "  2) Claude Code"
   echo "  3) Cursor"
   echo "  4) Codex"
@@ -127,28 +154,32 @@ interactive() {
   echo "  a) All    q) Quit"
   echo ""
   read -rp "Choose agents (comma-separated, e.g. 1,2): " choice
+  # Default to Copilot on empty input
+  if [[ -z "${choice//[[:space:]]/}" ]]; then
+    choice="1"
+  fi
   [[ "$choice" == [qQ] ]] && exit 0
 
-  local agent_flags=()
+  local agents=()
   if [[ "$choice" == [aA] ]]; then
-    agent_flags=("" "--agent claude-code" "--agent cursor" "--agent codex" "--agent gemini")
+    agents=("" "claude-code" "cursor" "codex" "gemini")
   else
     IFS=',' read -ra sel <<< "$choice"
     for s in "${sel[@]}"; do
       case "$(echo "$s" | tr -d ' ')" in
-        1) agent_flags+=("") ;;
-        2) agent_flags+=("--agent claude-code") ;;
-        3) agent_flags+=("--agent cursor") ;;
-        4) agent_flags+=("--agent codex") ;;
-        5) agent_flags+=("--agent gemini") ;;
+        1) agents+=("") ;;
+        2) agents+=("claude-code") ;;
+        3) agents+=("cursor") ;;
+        4) agents+=("codex") ;;
+        5) agents+=("gemini") ;;
         *) warn "Unknown: $s" ;;
       esac
     done
   fi
 
-  for flag in "${agent_flags[@]}"; do
+  for agent in "${agents[@]}"; do
     for skill in "${skills[@]}"; do
-      install_skill "$skill" "$flag"
+      install_skill "$skill" "$agent"
     done
   done
 
@@ -165,22 +196,36 @@ main() {
 
   # gh skill requires v2.90.0+
   local gh_version
-  gh_version=$(gh --version | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+  gh_version=$(gh --version | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true)
   local required="2.90.0"
-  if printf '%s\n%s\n' "$required" "$gh_version" | sort -V -C 2>/dev/null; then
-    : # version is sufficient
-  else
+
+  if [[ -z "$gh_version" || ! "$gh_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    error "Could not determine GitHub CLI version"
+    info "Expected 'gh --version' to contain a semantic version like X.Y.Z"
+    info "See https://cli.github.com"
+    exit 1
+  fi
+
+  if ! version_ge "$gh_version" "$required"; then
     error "GitHub CLI v${required}+ is required for 'gh skill' (found v${gh_version})"
     info "Upgrade with: brew upgrade gh (macOS) or see https://cli.github.com"
     exit 1
   fi
 
-  local agent_flags=()
+  local agents=()
   local install_all=false
 
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --agent)    shift; agent_flags+=("--agent $1") ;;
+      --agent)
+        shift
+        if [[ $# -eq 0 ]]; then
+          error "Missing value for --agent"
+          usage
+          exit 1
+        fi
+        agents+=("$1")
+        ;;
       --all)      install_all=true ;;
       --dry-run)  DRY_RUN=true ;;
       -h|--help)  usage; exit 0 ;;
@@ -208,21 +253,21 @@ main() {
     error "No skills found in $SCRIPT_DIR"; exit 1
   fi
 
-  # No flags — go interactive
-  if ! $install_all && [[ ${#agent_flags[@]} -eq 0 ]]; then
+  # No agents or --all specified and not dry-run-only — go interactive
+  if ! $install_all && [[ ${#agents[@]} -eq 0 ]] && ! $DRY_RUN; then
     interactive; exit 0
   fi
 
   if $install_all; then
-    agent_flags=("" "--agent claude-code" "--agent cursor" "--agent codex" "--agent gemini")
+    agents=("" "claude-code" "cursor" "codex" "gemini")
   fi
 
-  # Default to Copilot if no agent specified
-  [[ ${#agent_flags[@]} -eq 0 ]] && agent_flags+=("")
+  # Default to Copilot if only --dry-run was passed
+  [[ ${#agents[@]} -eq 0 ]] && agents+=("")
 
-  for flag in "${agent_flags[@]}"; do
+  for agent in "${agents[@]}"; do
     for skill in "${skills[@]}"; do
-      install_skill "$skill" "$flag"
+      install_skill "$skill" "$agent"
     done
   done
 

--- a/skills/setup.sh
+++ b/skills/setup.sh
@@ -9,6 +9,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO="camunda/.github"
+SOURCE="$REPO"
+SOURCE_IS_LOCAL=false
 
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -27,11 +29,30 @@ DRY_RUN=false
 # Discover skills — each subdirectory containing a SKILL.md
 # ---------------------------------------------------------------------------
 discover_skills() {
+  local base_dir="${1:-$SCRIPT_DIR}"
   local skills=()
-  for dir in "$SCRIPT_DIR"/*/; do
+  for dir in "$base_dir"/*/; do
+    [[ -f "$dir/SKILL.md" ]] && skills+=("$(basename "$dir")")
+  done
+  for dir in "$base_dir"/skills/*/; do
     [[ -f "$dir/SKILL.md" ]] && skills+=("$(basename "$dir")")
   done
   echo "${skills[@]}"
+}
+
+# Prefer local checkout when running inside a git worktree with skills.
+auto_detect_local_source() {
+  local repo_root
+  repo_root=$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null || true)
+  [[ -n "$repo_root" ]] || return 1
+
+  local found
+  found="$(discover_skills "$repo_root")"
+  [[ -n "$found" ]] || return 1
+
+  SOURCE="$repo_root"
+  SOURCE_IS_LOCAL=true
+  return 0
 }
 
 # ---------------------------------------------------------------------------
@@ -39,14 +60,17 @@ discover_skills() {
 # ---------------------------------------------------------------------------
 install_skill() {
   local skill="$1" agent_flag="${2:-}"
+  local cmd=(gh skill install "$SOURCE" "$skill")
+  $SOURCE_IS_LOCAL && cmd+=(--from-local)
+  [[ -n "$agent_flag" ]] && cmd+=($agent_flag)
 
   if $DRY_RUN; then
-    info "Would run: gh skill install $REPO $skill $agent_flag"
+    info "Would run: ${cmd[*]}"
     return
   fi
 
   local output
-  if output=$(gh skill install "$REPO" "$skill" $agent_flag 2>&1); then
+  if output=$("${cmd[@]}" 2>&1); then
     success "$skill installed${agent_flag:+ ($agent_flag)}"
   elif [[ "$output" == *"already"* ]]; then
     info "$skill already installed${agent_flag:+ ($agent_flag)} (skipped)"
@@ -87,7 +111,9 @@ interactive() {
   echo ""
 
   local skills
-  read -ra skills <<< "$(discover_skills)"
+  local discovery_root="$SCRIPT_DIR"
+  $SOURCE_IS_LOCAL && discovery_root="$SOURCE"
+  read -ra skills <<< "$(discover_skills "$discovery_root")"
   echo "  Skills to install:"
   for s in "${skills[@]}"; do
     echo "    - $s"
@@ -163,8 +189,20 @@ main() {
     shift
   done
 
+  if ! $SOURCE_IS_LOCAL; then
+    auto_detect_local_source || true
+  fi
+
+  if $SOURCE_IS_LOCAL; then
+    [[ -d "$SOURCE" ]] || { error "Local source directory not found: $SOURCE"; exit 1; }
+  fi
+
   local skills
-  read -ra skills <<< "$(discover_skills)"
+  if $SOURCE_IS_LOCAL; then
+    read -ra skills <<< "$(discover_skills "$SOURCE")"
+  else
+    read -ra skills <<< "$(discover_skills "$SCRIPT_DIR")"
+  fi
 
   if [[ ${#skills[@]} -eq 0 ]]; then
     error "No skills found in $SCRIPT_DIR"; exit 1

--- a/skills/setup.sh
+++ b/skills/setup.sh
@@ -192,26 +192,6 @@ interactive() {
 }
 
 main() {
-  command -v gh &>/dev/null || { error "GitHub CLI (gh) is required — install from https://cli.github.com"; exit 1; }
-
-  # gh skill requires v2.90.0+
-  local gh_version
-  gh_version=$(gh --version | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true)
-  local required="2.90.0"
-
-  if [[ -z "$gh_version" || ! "$gh_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    error "Could not determine GitHub CLI version"
-    info "Expected 'gh --version' to contain a semantic version like X.Y.Z"
-    info "See https://cli.github.com"
-    exit 1
-  fi
-
-  if ! version_ge "$gh_version" "$required"; then
-    error "GitHub CLI v${required}+ is required for 'gh skill' (found v${gh_version})"
-    info "Upgrade with: brew upgrade gh (macOS) or see https://cli.github.com"
-    exit 1
-  fi
-
   local agents=()
   local install_all=false
 
@@ -233,6 +213,26 @@ main() {
     esac
     shift
   done
+
+  command -v gh &>/dev/null || { error "GitHub CLI (gh) is required — install from https://cli.github.com"; exit 1; }
+
+  # gh skill requires v2.90.0+
+  local gh_version
+  gh_version=$(gh --version | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || true)
+  local required="2.90.0"
+
+  if [[ -z "$gh_version" || ! "$gh_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    error "Could not determine GitHub CLI version"
+    info "Expected 'gh --version' to contain a semantic version like X.Y.Z"
+    info "See https://cli.github.com"
+    exit 1
+  fi
+
+  if ! version_ge "$gh_version" "$required"; then
+    error "GitHub CLI v${required}+ is required for 'gh skill' (found v${gh_version})"
+    info "Upgrade with: brew upgrade gh (macOS) or see https://cli.github.com"
+    exit 1
+  fi
 
   if ! $SOURCE_IS_LOCAL; then
     auto_detect_local_source || true

--- a/tests/setup-scripts.sh
+++ b/tests/setup-scripts.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# Smoke tests for mcp/setup.sh and skills/setup.sh
+# Runs both scripts in dry-run / error paths only — no files are modified.
+#
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); echo "  ✔ $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  ✘ $1"; }
+
+assert_exit() {
+  local expected="$1" actual="$2" label="$3"
+  if [[ "$actual" -eq "$expected" ]]; then pass "$label"; else fail "$label (expected exit $expected, got $actual)"; fi
+}
+
+assert_contains() {
+  local needle="$1" haystack="$2" label="$3"
+  if echo "$haystack" | grep -q "$needle"; then pass "$label"; else fail "$label (expected '$needle' in output)"; fi
+}
+
+# =========================================================================
+echo ""
+echo "=== skills/setup.sh ==="
+echo ""
+
+SKILLS="$REPO_ROOT/skills/setup.sh"
+
+# -- dry-run defaults to Copilot, no interactive prompt
+out=$($SKILLS --dry-run 2>&1) ; rc=$?
+assert_exit 0 "$rc" "--dry-run exits 0"
+assert_contains "Would run" "$out" "--dry-run prints planned commands"
+assert_contains "check-architecture-principles" "$out" "--dry-run discovers architecture skill"
+assert_contains "check-camunda-docs" "$out" "--dry-run discovers docs skill"
+
+# -- dry-run with specific agent
+out=$($SKILLS --dry-run --agent claude-code 2>&1) ; rc=$?
+assert_exit 0 "$rc" "--dry-run --agent claude-code exits 0"
+assert_contains "claude-code" "$out" "--agent claude-code appears in output"
+
+# -- dry-run with --all
+out=$($SKILLS --dry-run --all 2>&1) ; rc=$?
+assert_exit 0 "$rc" "--dry-run --all exits 0"
+assert_contains "claude-code" "$out" "--all includes claude-code"
+assert_contains "cursor" "$out" "--all includes cursor"
+assert_contains "gemini" "$out" "--all includes gemini"
+
+# -- --agent without value
+out=$($SKILLS --agent 2>&1 || true)
+assert_contains "Missing value" "$out" "--agent without value shows error"
+
+# -- unknown option
+out=$($SKILLS --bogus 2>&1 || true)
+assert_contains "Unknown option" "$out" "unknown option shows error"
+
+# -- help
+out=$($SKILLS --help 2>&1) ; rc=$?
+assert_exit 0 "$rc" "--help exits 0"
+assert_contains "Usage" "$out" "--help shows usage"
+
+# =========================================================================
+echo ""
+echo "=== mcp/setup.sh ==="
+echo ""
+
+MCP="$REPO_ROOT/mcp/setup.sh"
+
+# -- dry-run with --vscode (requires jq)
+if command -v jq &>/dev/null; then
+  out=$($MCP --dry-run --vscode 2>&1) ; rc=$?
+  assert_exit 0 "$rc" "--dry-run --vscode exits 0"
+  assert_contains "Would merge" "$out" "--dry-run --vscode previews merge"
+  assert_contains "camunda-docs" "$out" "--dry-run --vscode includes camunda-docs"
+else
+  echo "  ⊘ skipped --vscode tests (jq not installed)"
+fi
+
+# -- dry-run with --jetbrains (requires jq)
+if command -v jq &>/dev/null; then
+  out=$($MCP --dry-run --jetbrains 2>&1) ; rc=$?
+  assert_exit 0 "$rc" "--dry-run --jetbrains exits 0"
+  assert_contains "Would merge" "$out" "--dry-run --jetbrains previews merge"
+else
+  echo "  ⊘ skipped --jetbrains tests (jq not installed)"
+fi
+
+# -- unknown option
+out=$($MCP --bogus 2>&1 || true)
+assert_contains "Unknown option" "$out" "unknown option shows error"
+
+# -- help
+out=$($MCP --help 2>&1) ; rc=$?
+assert_exit 0 "$rc" "--help exits 0"
+assert_contains "Usage" "$out" "--help shows usage"
+
+# =========================================================================
+echo ""
+echo "--- Results: $PASS passed, $FAIL failed ---"
+echo ""
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

- **Add two Agent Skills** (`skills/` directory) following the [agentskills.io](https://agentskills.io) specification:
  - `check-architecture-principles` — validates structural/foundational changes against architecture principles using `gh` CLI (with `github` MCP fallback)
  - `check-camunda-docs` — searches Camunda 8 docs for domain knowledge via the `camunda-docs` MCP server
- **Add `skills/setup.sh`** — interactive installer (mirrors `mcp/setup.sh`) that auto-discovers skills and installs them for GitHub Copilot, Claude Code, Cursor, Codex, or Gemini CLI. Includes `gh` version check (requires v2.90.0+).
- **Update `AGENTS.md`** — cross-reference table now points to skills instead of describing MCP procedures inline. New "Tooling Preconditions" section nudges agents to verify `gh auth status` and `gh skill update` at session start.
- **Update `README.md`** — new "Developer Setup" section with two-step flow: MCP servers + agent skills.

### Why

Previously, cross-reference procedures (e.g., "use the `github` MCP server to check architecture principles") were described as prose in `AGENTS.md`. Agents might follow through or not, and there was no consistency in how they performed the check. By moving these into executable, versioned, updatable skills:

- The procedure is **consistent and repeatable** across agents
- Skills are **distributable** via `gh skill install` and **updateable** via `gh skill update`
- `AGENTS.md` stays focused on **principles** (what to check), skills handle **procedures** (how to check)

### Related

- Companion PR: camunda/ai-first-template#4 (updates onboarding to reference skills setup)

## Test plan

- [ ] Run `skills/setup.sh --dry-run` and verify it discovers both skills
- [ ] Run `skills/setup.sh --agent claude-code --dry-run` and verify correct `gh skill install` commands
- [ ] Run `skills/setup.sh` with `gh` < v2.90.0 and verify clear error message
- [ ] Verify `skills/README.md` documents all available skills
- [ ] Verify `AGENTS.md` references skills instead of MCP procedures

🤖 Generated with [Claude Code](https://claude.com/claude-code)