### PR TITLE
feat: drop MCP for docs fetching

### DIFF
--- a/.github/workflows/test-setup-scripts.yml
+++ b/.github/workflows/test-setup-scripts.yml
@@ -11,16 +11,16 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Ensure gh 2.90.0+
+      - uses: actions/checkout@v6
+      - name: Ensure gh-skill is available
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          gh --version
-          gh extension install gh-skill 2>/dev/null || true
           if ! gh skill --help >/dev/null 2>&1; then
-            curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-            echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-            sudo apt-get update && sudo apt-get install -y gh
+            GH_VER=$(curl -fsSL https://api.github.com/repos/cli/cli/releases/latest | grep -oP '"tag_name": "v\K[^"]+')
+            curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VER}/gh_${GH_VER}_linux_amd64.tar.gz" \
+              | tar -xz -C /tmp
+            sudo install -m755 "/tmp/gh_${GH_VER}_linux_amd64/bin/gh" /usr/local/bin/gh
           fi
-          gh --version
       - name: Run smoke tests
         run: ./tests/setup-scripts.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .claude/
+.agents/

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -21,7 +21,6 @@ Or pass flags directly:
 
 | MCP Server | Description | VS Code | Claude Code | Claude Desktop | JetBrains |
 |---|---|:---:|:---:|:---:|:---:|
-| `camunda-docs` | Camunda 8 documentation search via [kapa.ai](https://camunda-docs.mcp.kapa.ai) | ✔ | ✔ | ✔ | ✔ |
 | `github` | GitHub tools via [GitHub MCP Server](https://github.com/github/github-mcp-server) | ✔ | ✔ | ✔ | — |
 
 > **Note:** In VS Code the `github` MCP server authenticates via the Copilot extension. In Claude Code it requires a [GitHub Personal Access Token](https://github.com/settings/personal-access-tokens/new). In Claude Desktop, authenticate via Settings → Connectors.

--- a/mcp/gh-copilot.json
+++ b/mcp/gh-copilot.json
@@ -3,10 +3,6 @@
     "github": {
       "type": "http",
       "url": "https://api.githubcopilot.com/mcp/"
-    },
-    "camunda-docs": {
-      "type": "http",
-      "url": "https://camunda-docs.mcp.kapa.ai"
     }
   }
 }

--- a/mcp/jetbrains.json
+++ b/mcp/jetbrains.json
@@ -1,7 +1,3 @@
 {
-  "mcpServers": {
-    "camunda-docs": {
-      "url": "https://camunda-docs.mcp.kapa.ai"
-    }
-  }
+  "mcpServers": {}
 }

--- a/mcp/setup.sh
+++ b/mcp/setup.sh
@@ -110,19 +110,8 @@ install_claude() {
 
   if $DRY_RUN; then
     info "Would run:"
-    info "  claude mcp add --transport http --scope user camunda-docs https://camunda-docs.mcp.kapa.ai"
     info "  claude mcp add-json --scope user github '<config with GitHub PAT>'"
     return
-  fi
-
-  # camunda-docs — no auth required
-  local add_output
-  if add_output=$(claude mcp add --transport http --scope user camunda-docs https://camunda-docs.mcp.kapa.ai 2>&1); then
-    success "Claude: camunda-docs added"
-  elif [[ "$add_output" == *"already exists"* ]]; then
-    info "Claude: camunda-docs already configured (skipped)"
-  else
-    error "Claude: camunda-docs failed — $add_output"; return 1
   fi
 
   # github — requires a GitHub Personal Access Token
@@ -156,8 +145,6 @@ install_claude_desktop() {
   echo "  2. Go to Settings → Connectors"
   echo "  3. The following connectors already exist in your organization."
   echo "     Click \"Connect\" next to each one to enable it:"
-  echo ""
-  echo -e "     ${BOLD}Camunda Docs${NC}  (camunda-docs)"
   echo ""
   echo -e "     ${BOLD}GitHub${NC}  (github)"
   echo "       (Authenticate with your GitHub account when prompted)"

--- a/mcp/vscode.json
+++ b/mcp/vscode.json
@@ -3,10 +3,6 @@
     "github": {
       "type": "http",
       "url": "https://api.githubcopilot.com/mcp/"
-    },
-    "camunda-docs": {
-      "type": "http",
-      "url": "https://camunda-docs.mcp.kapa.ai"
     }
   }
 }

--- a/skills/check-camunda-docs/SKILL.md
+++ b/skills/check-camunda-docs/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: check-camunda-docs
 description: Searches Camunda 8 documentation for domain knowledge needed during implementation. Use when a change involves Camunda-specific concepts, APIs, configuration, or behavior — such as BPMN, DMN, Zeebe, Connectors, Operate, Tasklist, Identity, or any Camunda platform component.
-compatibility: Requires the `camunda-docs` MCP server configured via camunda/.github/mcp/setup.sh
+compatibility: "No MCP server required; uses public docs search URLs."
 metadata:
   author: camunda
 ---
@@ -26,8 +26,11 @@ Identify the Camunda concepts relevant to the current change.
 
 ### 2. Search documentation
 
-Query the `camunda-docs` MCP server with a focused search term.
+Use the public Camunda Docs search route with a focused search term:
 
+- `https://docs.camunda.io/search/?q=<search-query>`
+  - `<search-query>` should be URL-encoded (percent-encoded); spaces to be encoded as `%20`.
+- Open and read the most relevant result pages directly from docs.camunda.io
 - Prefer specific terms over broad ones (e.g., "Zeebe gateway timeout configuration" over "Zeebe config")
 - If the first query returns insufficient results, refine and retry with alternative terms
 

--- a/tests/setup-scripts.sh
+++ b/tests/setup-scripts.sh
@@ -75,7 +75,6 @@ if command -v jq &>/dev/null; then
   out=$($MCP --dry-run --vscode 2>&1) ; rc=$?
   assert_exit 0 "$rc" "--dry-run --vscode exits 0"
   assert_contains "Would merge" "$out" "--dry-run --vscode previews merge"
-  assert_contains "camunda-docs" "$out" "--dry-run --vscode includes camunda-docs"
 else
   echo "  ⊘ skipped --vscode tests (jq not installed)"
 fi


### PR DESCRIPTION
This pull request removes the dedicated `camunda-docs` MCP server from the default configuration, updating documentation and setup scripts to reflect that Camunda 8 docs are public and can be accessed directly via search URLs. The `check-camunda-docs` skill and related documentation are updated to recommend using direct search and fetching of docs, with the MCP server now optional.

Demo:

<img width="473" height="552" alt="Screenshot 2026-04-20 at 22 47 07" src="https://github.com/user-attachments/assets/1c9e23dc-ed8c-4512-8497-5463a698e589" />
