### PR TITLE
Revert "Add issue template config to redirect new issues to ai-first-template"

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,0 @@
-blank_issues_enabled: false
-contact_links:
-  - name: New Issue
-    url: https://github.com/camunda/ai-first-template/issues/new
-    about: Please create all issues in the ai-first-template repository.


### PR DESCRIPTION
Reverts camunda/.github#18

This change is cascaded throughout all repos which was not the intention.