### PR TITLE
Add product-sense-review skill

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -26,6 +26,7 @@ If you run `./setup.sh` from inside a git checkout that contains these skills, t
 | `check-architecture-principles` | Validates structural/foundational changes against Camunda architecture principles |
 | `check-camunda-docs` | Searches Camunda 8 docs for domain knowledge needed during implementation |
 | `create-architecture-decision` | Creates an Architecture Decision Record (ADR) in Markdown format from a design discussion (e.g. Google Drive document, github issue) |
+| `review-spec` | Reviews an engineering spec, design doc, or WIP RFC with a PM/architect lens — surfaces forks, gaps, dependencies, and strategic-fit questions. Posts review inline in chat; writes no files. |
 
 ## Prerequisites
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -26,7 +26,7 @@ If you run `./setup.sh` from inside a git checkout that contains these skills, t
 | `check-architecture-principles` | Validates structural/foundational changes against Camunda architecture principles |
 | `check-camunda-docs` | Searches Camunda 8 docs for domain knowledge needed during implementation |
 | `create-architecture-decision` | Creates an Architecture Decision Record (ADR) in Markdown format from a design discussion (e.g. Google Drive document, github issue) |
-| `review-spec` | Reviews an engineering spec, design doc, or WIP RFC with a PM/architect lens — surfaces forks, gaps, dependencies, and strategic-fit questions. Posts review inline in chat; writes no files. |
+| `product-sense-review` | Reviews a WIP engineering spec, design doc, or RFC through a product-sense lens — problem framing, user fit, product fit, and framing for the team to act on. Posts review inline in chat; writes no files. |
 
 ## Prerequisites
 

--- a/skills/product-sense-review/SKILL.md
+++ b/skills/product-sense-review/SKILL.md
@@ -1,13 +1,14 @@
 ---
-name: review-spec
+name: product-sense-review
 description: |
-  Review an engineering spec, design doc, or WIP RFC before implementation.
-  Applies a PM/architect lens, surfaces forks, gaps, dependencies, and
-  strategic-fit questions. Output is a structured review posted inline in
-  the conversation — does NOT write files to the working directory.
+  Review an engineering spec, design doc, or WIP RFC through a product-sense
+  lens — problem framing, user fit, product fit, and whether the spec is
+  framed clearly enough for the team to act on it. Use before implementation
+  begins, on work-in-progress specs. Output is a structured review posted
+  inline in the conversation — does NOT write files to the working directory.
   Triggers on: "review this spec", "review this RFC", "review this design",
-  "PM review", "spec review", a GitHub issue/PR link containing a spec body,
-  a Google Doc design doc link, or a pasted spec.
+  "PM review", "spec review", "product-sense review", a GitHub issue/PR link
+  containing a spec body, a Google Doc design doc link, or a pasted spec.
 
   Use when user: asks for a structured review of an engineering proposal
   before Define/build; needs to surface cross-product dependencies or
@@ -16,9 +17,9 @@ description: |
   on a colleague's spec.
 ---
 
-# Review an Engineering Spec
+# Product-Sense Review
 
-Review a work-in-progress engineering spec, design doc, or RFC. Make implicit things explicit, surface forks rather than block momentum, apply a PM/architect lens — *not* gatekeep ship-readiness.
+Review a work-in-progress engineering spec, design doc, or RFC through a product-sense lens. Make implicit things explicit, surface forks rather than block momentum — *not* gatekeep ship-readiness.
 
 The bar is not "is this complete." The bar is: **are we solving the right problem, in roughly the right way, with the right things made visible to the team?**
 
@@ -167,7 +168,7 @@ Use the priority markers `[Must]` / `[Should]` / `[Nit]` in front of every actio
 [Concrete follow-ups. Skip if none.]
 ```
 
-End the review with: *"Reply with feedback on this review and I'll refine it."*
+End the review with: *"Reply with feedback on this review and I'll capture it."*
 
 ## Camunda terminology to check against
 

--- a/skills/review-spec/SKILL.md
+++ b/skills/review-spec/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: review-spec
+description: |
+  Review an engineering spec, design doc, or WIP RFC before implementation.
+  Applies a PM/architect lens, surfaces forks, gaps, dependencies, and
+  strategic-fit questions. Output is a structured review posted inline in
+  the conversation — does NOT write files to the working directory.
+  Triggers on: "review this spec", "review this RFC", "review this design",
+  "PM review", "spec review", a GitHub issue/PR link containing a spec body,
+  a Google Doc design doc link, or a pasted spec.
+
+  Use when user: asks for a structured review of an engineering proposal
+  before Define/build; needs to surface cross-product dependencies or
+  hidden deferrals; wants to validate problem framing, scope, and edge
+  states before committing to implementation; or wants a second opinion
+  on a colleague's spec.
+---
+
+# Review an Engineering Spec
+
+Review a work-in-progress engineering spec, design doc, or RFC. Make implicit things explicit, surface forks rather than block momentum, apply a PM/architect lens — *not* gatekeep ship-readiness.
+
+The bar is not "is this complete." The bar is: **are we solving the right problem, in roughly the right way, with the right things made visible to the team?**
+
+## When to use
+
+- The user posts a link to a spec (GitHub issue/PR, Google Doc, Figma, etc.) or pastes spec text and asks for a review.
+- A colleague has shared a design doc and the user wants a structured second opinion before signing off.
+- A spec is approaching a phase gate (e.g. Discovery → Define) and the author wants pre-gate scrutiny.
+
+## What this skill does NOT do
+
+- Does **not** write files to the working directory. Output is posted in the conversation. The user routes it (GitHub comment, Slack, save to a doc).
+- Does **not** maintain cross-spec memory. If you want accumulating per-epic memory across reviews, see the PM toolkit version of this skill in [camunda/camunda-ai-pm-toolkit](https://github.com/camunda/camunda-ai-pm-toolkit).
+- Does **not** auto-post the review anywhere — the user decides where it goes.
+
+## Input
+
+The skill accepts:
+
+- A GitHub issue or PR link (read via the `github` MCP / `gh`)
+- A Google Doc link (read via the Google Drive MCP, if configured)
+- A Figma link (read via the Figma MCP, if configured)
+- A file path
+- Pasted spec content
+
+If nothing is provided, ask: *"What spec would you like reviewed? Paste a link, path, or the spec content."*
+
+If the source can't be fetched, ask the user to paste it.
+
+## Workflow
+
+### 1. Read the spec
+
+Fetch the full content. Read fully before reviewing — skimming produces shallow reviews.
+
+### 2. Gather context (conditional)
+
+Only read sources that the spec actually touches. Don't dump findings; use context to inform the review and cite where relevant.
+
+| Source | Read when |
+|---|---|
+| `camunda/product-hub` issues | Related epics, engineering comments on prior decisions/constraints (via `github` MCP) |
+| `camunda/camunda-hub` PRs/issues | Implementation already in flight, parallel work |
+| `camunda/product-development/strategy/` | Spec touches a strategic bet or cross-domain coherence is in question |
+| `camunda/product-development/research/personas/` | Spec names personas or makes behavioral claims about users |
+| Camunda Docs (via `camunda-docs` MCP) | Current product state — what already ships, terminology, behavior reference |
+| Asana (Hub board), Google Drive, Figma, Company Handbook | Optional — read only if the corresponding MCP is configured and the spec calls for it |
+
+### 3. Confirm framing (only if needed)
+
+Ask only what you genuinely need answered. Skip any dimension that's obvious from the spec or context. If multiple are unclear, ask them together in one short message.
+
+Candidate questions:
+- **Origin**: Where did this work originate? (Field-driven ask, PM-identified, bug, internal eng need.) Framing should match: field-driven asks need evidence of breadth, PM-identified needs a strategic thesis, bugs should explain why this one now.
+- **Ambition**: What's the ambition level? *"Good enough"* vs. *"make-or-break for adoption"* changes the review depth.
+- **Focus**: Any specific area to push on, or a general review?
+
+If all are clear, skip step 3 entirely.
+
+### 4. Apply the review lens
+
+Use the mandatory checks every time. Use the menu as a *menu* — pick 3–6 items that genuinely apply. Mentioning all of them is a failure mode; selectivity is the value.
+
+#### Mandatory (every review)
+
+- **Problem framing.** Is the user problem clearly and correctly scoped? Why now? Does the framing match its source (field evidence, strategic thesis, bug priority)?
+- **Summary test.** Restate the spec in one paragraph in your own words. If you can't, say so and point to what's muddled.
+- **Unstated assumptions.** What's the spec assuming about scale, audience, infrastructure, identity, migration, rollback, licensing, defaults, the median user? Frame as questions.
+- **Empty and edge states.** What does the UI/system say when there's nothing to show, or when things break? Specs almost always under-specify this.
+
+#### Menu — pick what applies
+
+**Is this the right thing?**
+
+- **Capability fit — should this exist?** Who is this for, and does enabling it conflict with how we want users to work? *"Why would we allow X from here when the intended path is Y?"* is a valid question.
+- **Workflow friction.** For core user actions, count the clicks/screens. Is the action discoverable from where the user already is?
+- **JTBD and personas.** What jobs-to-be-done? Which personas? Are any explicitly out of scope or being silently dropped? Does behavior differ by user type, and is that called out?
+- **User journey.** Where does the user come from? Where do they go after? What knowledge do they bring in, and is it enough?
+- **Investment level.** Is the spec's ambition matched to its level of detail? If not explicit, ask.
+- **Cross-product coherence.** Is this consistent with other Camunda work — Web Modeler, Console, Optimize, Operate, Tasklist, Hub? Name specific other epics, owners, or in-flight work — generic *"consider other domains"* isn't enough.
+- **Happy path and edge cases.** Both covered? SaaS and Self-Managed aligned, or deliberately different? If different, is the divergence named?
+- **Scope discipline.** What's the minimum viable version to learn from? Default to the simplest version that ships value. *It's always harder to remove something we shipped than to add something we didn't.*
+
+**Is it framed well enough for the team to act on?**
+
+- **Buried lede.** Does the spec answer the reader's first question early?
+- **Terminology landmines.** Words reused with new meanings, new terms introduced without grounding, overloaded terms (Project, Workspace, package, cluster, scope). See **Camunda terminology** section below.
+- **Multi-purpose controls.** Does any UI element or API do more than one thing? Often it's doing two unrelated jobs and surfacing that exposes a real product question.
+- **Microcopy.** For any UI string in the spec, would a user understand it cold? Propose replacements, don't only flag.
+- **Pattern consistency.** Is this consistent with the rest of the product, or introducing a new pattern? New patterns need a reason.
+- **Helper text in context.** Where the UI doesn't explain itself, propose the missing in-context string.
+- **Layer separation.** Runtime vs. design-time. Infrastructure vs. product. Governance vs. execution. Blocking vs. informational.
+- **Edges, not median.** Regulated/banking customers, Self-Managed users, IDP-only orgs. Concrete edges, not generic *"consider security."*
+- **Deferred work, logged.** Deferring is fine. *Unlogged* deferring is the problem. If a deferral isn't captured (what, why safe now, future trigger), surface it.
+- **Out-of-box defaults.** Defaults rarely match real org structures. Ask what's customizable beyond them.
+
+### 5. Post the review
+
+Post the review directly in chat as your reply. **Do not write any files to the working directory.** The user decides where the review goes (GitHub comment, Slack, save manually).
+
+Use the priority markers `[Must]` / `[Should]` / `[Nit]` in front of every actionable item. Lead with a **TL;DR** listing the Musts so the reader can triage in 30 seconds. Skip any section that has no content.
+
+#### Output template
+
+```markdown
+# Review: [Spec title]
+**Source**: [link]
+**Lens applied**: [one line — what you covered and what you deliberately skipped]
+
+## TL;DR — Resolve before Define
+[List only the Must items, one line each with the one-line reason. If no Musts, write "No blockers." Aim for 3–6 max — more than that means the review is mis-prioritized.]
+
+## Summary
+[One paragraph: what this spec proposes, in your own words. If you can't summarize it, say so and point to what's muddled.]
+
+## What's working
+[0–4 bullets. Skip the section entirely if nothing genuinely strong.]
+
+## Decision points
+[Forks where the spec picked a path. For each: what was chosen, the alternative, the tradeoff, my ranked preference + one-line reason (vote, don't only ask). Skip the section if no clear forks.]
+
+## Findings
+[Priority-marked. Include a concrete scenario as an inline sub-bullet when one illustrates the problem. Narrate user mental model in plain language when relevant: "(why is this greyed out? ah, because…)".]
+- **[Must] [Short title]** — [the finding, framed as a question when possible]
+  - *Scenario:* [specific user path with real names/numbers/timing]
+- **[Should] [Short title]** — [the finding]
+- **[Nit] [Short title]** — [the finding]
+
+## Empty / edge states
+[Specific states the spec under-specifies. Propose the missing copy or behavior. Skip if not relevant.]
+
+## Cross-product impact
+[Named other epics, owners, in-flight work. Priority-marked. Skip if nothing relevant.]
+- **[Must] [Name + issue/task ID]** — [the dependency or conflict]
+
+## Hidden deferrals
+[Things the spec is silently leaving out without logging as future work. Either resolve, or add to the spec's Future Considerations. Format: "[What's deferred] — suggested future trigger." Skip if none.]
+
+## Questions for the author
+[3–5 ranked questions that would resolve the most uncertainty. Skip if no open questions.]
+
+## Open for someone else
+[Things to delegate explicitly. Format: "[Concern] — for [role/person]." Skip if none.]
+
+## Suggested next steps
+[Concrete follow-ups. Skip if none.]
+```
+
+End the review with: *"Reply with feedback on this review and I'll refine it."*
+
+## Camunda terminology to check against
+
+Inline reference so the skill doesn't depend on an external file. Flag any of the following in the spec being reviewed:
+
+- Use **"agentic orchestration"** (lowercase) as a category. Capitalize only in proper titles.
+- Use **"Business Orchestration Platform (BOP)"** for the architectural vision only, not to describe Camunda today.
+- Use **"orchestration layer"** when describing Camunda's current role within the BOP.
+- Use **"platform"** when referring to the BOP. Never use "layer" or "architecture" as substitutes.
+- **Never** use "workflow tool," "automation platform," or "BPM suite" to describe Camunda. Zeebe can be called a "workflow engine."
+- Do not refer to Camunda as "The Orchestration Company."
+- Spell out "line of business" and "line-of-business leader" on first use. Abbreviate as LoB only after first use.
+
+## Reviewer discipline
+
+These shape the *voice and method*, not just the content. Apply throughout.
+
+- **Walk through it like a user, in plain language.** When critiquing UX, narrate what a user would think on first encounter. Use parentheses for the internal monologue: *"(why is this greyed out? ah, because these aren't deleted, ok…)"*. If the feature requires the user to learn something to make sense of it, that's a flag.
+- **Concrete scenarios, with numbers and named entities.** Edge cases must be specific paths. *"A file deleted today, container deleted in 5 days"* beats *"time-handling could be confusing."*
+- **Vote when there's a choice.** State a ranked preference with a one-line reason. *"I vote A or B — A keeps it dumb and simple, B is a bit nicer."* No hedging.
+- **Floor-first.** Default to the simplest version that ships value. The bar to add complexity is evidence of need, not anticipation.
+- **Try to break it on paper.** If a constraint isn't stated, name a path that violates it and ask. *"Can I save V1, then V2, then V1 again? If yes, is that the intent?"*
+- **Probe what controls actually do.** When a UI element or API method's purpose isn't self-evident, ask. Often it's doing two things at once.
+- **Suggest, don't only object.** When flagging unclear UI, propose the replacement copy or alternative path. *"I would have a helper text there like: 'When you compare 2 versions this window will list all the changes'."*
+- **Name names for cross-product impact.** Specific other epics, owners, issues — not generic *"consider other domains."* If you can't name them, the dependency isn't real.
+- **Surface absences, not just critique presence.** *"Where can I see the 'missing parent' flow?"* — the gap is part of the review.
+- **Delegate explicitly when you don't have the answer.** *"Design should weigh in on placement."* *"Engineering should confirm whether project-ID rename is feasible."* These are valid review outputs.
+- **Frame unstated assumptions as questions.** *"Is this assuming X?"* beats *"This assumes X."*
+- **When the spec is solid on a dimension, say so plainly.** Don't pad. Don't invent problems to justify the review.
+- **Disengage cleanly once convinced.** If the author addresses a concern in the review thread, mark it resolved and move on.
+- **Short and selective beats long and checklist-y.** Selectivity is the value.
+
+## For richer use (cross-spec memory)
+
+If you review many specs over time and want accumulating per-epic memory so the second review of related work flags inconsistencies the first one logged, use the PM toolkit version of this skill from [camunda/camunda-ai-pm-toolkit](https://github.com/camunda/camunda-ai-pm-toolkit). The toolkit version writes an `epic-context/[slug].md` file per epic and a feedback log for periodic skill improvement.


### PR DESCRIPTION
## Summary

Adds a new org-wide `product-sense-review` skill for reviewing engineering specs, design docs, or WIP RFCs before implementation. Applies a **product-sense lens** — problem framing, user fit, product fit, and whether the spec is framed clearly enough for the team to act on it. Output is a structured review posted inline in chat — **the skill writes no files to the working directory** (an explicit design constraint from feedback by @Thorbenl).

## Why this skill

Spec review is a recurring workflow across PM, design, and engineering at Camunda. Today, review quality and depth varies per reviewer and per session. This skill makes the lens explicit, surfaces things specs commonly under-specify (empty states, hidden deferrals, cross-product impacts, persona grounding), and produces consistently structured, scannable reviews.

## Design choices

- **Self-contained** — inlines the Camunda terminology checklist; no dependency on an external CLAUDE.md or vault structure. Drop the SKILL.md anywhere and it works.
- **Zero file writes** — posts the review in chat so the user routes it (GitHub comment, Slack, save manually). Avoids polluting the working directory of whatever repo the engineer happens to be in.
- **MCP scope** — relies on `github` and `camunda-docs` (already configured by `mcp/setup.sh`). Asana, Google Drive, Figma, and the Camunda Company Handbook are treated as optional conditional reads (used only if configured and only if the spec calls for them).
- **Lens** — 4 mandatory checks (problem framing, summary test, unstated assumptions, empty/edge states) plus a menu of ~17 situational items grouped as *is this the right thing?* / *is it framed well enough to act on?*
- **TL;DR at the top** of every review listing `[Must]` items only — 30-second triage. `[Must]` / `[Should]` / `[Nit]` markers on every actionable finding.
- **Sections skip when empty** — short and selective beats checklist-y.
- **Reviewer discipline** baked in: narrate user mental model in plain language, concrete scenarios with numbers, vote on alternatives, floor-first bias, try-to-break-it probes, named cross-product dependencies (not generic *consider other domains*), delegate explicitly when the answer isn't yours.

## Provenance

Derived from and validated against the PM toolkit version at [camunda/camunda-ai-pm-toolkit#12](https://github.com/camunda/camunda-ai-pm-toolkit/pull/12) (also named `product-sense-review` there), trimmed for org-wide engineering use:
- Removed `epic-context/` cross-spec memory writes (toolkit-only)
- Removed `feedback/raw/` capture (toolkit-only)
- Removed vault folder reads (`Initiatives/`, `Meetings/`, etc.)
- Inlined the Camunda terminology rules (was a CLAUDE.md reference)
- Pointed users who want richer cross-spec memory to the toolkit version

Validated by running the original toolkit version against a real Discovery-phase epic ([camunda/product-hub#3567](https://github.com/camunda/product-hub/issues/3567)) — surfaced 4 Must-resolve items including an unlogged Desktop Modeler deferral, an ungrounded Org Admin role, and in-flight Asana dependencies the spec hadn't named.

## Test plan

- [ ] Install via `gh skill install camunda/.github product-sense-review`
- [ ] Run from inside a git repo without the PM toolkit checked out — confirm no files are created in the working directory
- [ ] Run against a `camunda/product-hub` issue link
- [ ] Run against a pasted spec
- [ ] Confirm the review posts inline, with TL;DR at the top
- [ ] Confirm sections are skipped when there's nothing to say

## Iteration

Happy to iterate on the lens, voice, and output shape based on feedback from anyone who runs it. The plan is to gather usage feedback for ~2 weeks, then refine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)