### PR TITLE
Shrink create-architecture-decision description to cut idle token cost

### DIFF
--- a/skills/create-architecture-decision/SKILL.md
+++ b/skills/create-architecture-decision/SKILL.md
@@ -1,14 +1,7 @@
 ---
 name: create-architecture-decision
 description: |
-  Create an Architecture Decision Record (ADR) as a Markdown file.
-  Triggers on: "write an ADR", "capture this decision", "migrate this doc into an ADR",
-  architecture folder, decision records, ADR numbering/renumbering, and requests to
-  turn a Google Doc / kickoff note / conversation outcome into a durable decision record.
-
-  Use when user: asks to create or migrate an ADR, records a just-made architectural
-  decision, adds a decision to an existing ADR folder (e.g. docs/adrs/),
-  or needs to align a draft with the house ADR format.
+  Creates or migrates an Architecture Decision Record (ADR) as a Markdown file, including numbering and cross-referencing. Triggers on: "write an ADR", "capture this decision", "migrate this doc into an ADR", turning a Google Doc / kickoff note / conversation into a durable decision record, ADR numbering/renumbering, adding to an ADR or architecture folder (e.g. docs/adrs/), or aligning a draft with the house ADR format.
 ---
 
 # Create an Architecture Decision Record


### PR DESCRIPTION
## Summary

- The `description` frontmatter is loaded every session in the available-skills list, even when the skill is never invoked
- Old description was ~90 tokens — a "Triggers on:" list followed by a redundant "Use when user:" paragraph covering the same ground
- New description is ~55 tokens and preserves every trigger phrase and every capability signal
- Skill body (the actual ADR-writing instructions) is unchanged

## What's preserved

All trigger terms kept verbatim:
- `"write an ADR"`, `"capture this decision"`, `"migrate this doc into an ADR"`
- Google Doc / kickoff note / conversation → durable decision record
- ADR numbering/renumbering
- `architecture folder` (restored after advisor review flagged it was silently dropped)
- adding to an ADR folder (e.g. `docs/adrs/`)
- aligning a draft with the house ADR format

🤖 Generated with [Claude Code](https://claude.com/claude-code)